### PR TITLE
Tests with WebApplicationFactory throws error when using environment with IHostEnvironment

### DIFF
--- a/Fhi.VersionApiClient/Fhi.VersionApiClient.csproj
+++ b/Fhi.VersionApiClient/Fhi.VersionApiClient.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0-beta1</Version>
     <IsPackable>true</IsPackable>
     <RepositoryUrl>https://github.com/FHIDev/Fhi.VersionApiClient</RepositoryUrl>
     <Authors>Folkehelseinstituttet (FHI)</Authors>

--- a/Fhi.VersionApiClient/VersionService.cs
+++ b/Fhi.VersionApiClient/VersionService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using Fhi.VersionApiClient.Exceptions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Refit;
 
@@ -65,6 +66,7 @@ public class VersionService : IVersionService
 {
     readonly string version;
     private readonly IVersionApi versionApi;
+    private readonly IHostEnvironment hostEnvironment;
     private readonly ILogger<VersionService> logger;
 
     /// <summary>
@@ -72,9 +74,11 @@ public class VersionService : IVersionService
     /// Add this in program.cs: services.AddScoped;
     /// </summary>
     /// <param name="versionApi"></param>
+    /// <param name="hostEnvironment"></param>
     /// <param name="logger"></param>
-    public VersionService(IVersionApi versionApi, ILogger<VersionService> logger)
+    public VersionService(IVersionApi versionApi, IHostEnvironment hostEnvironment, ILogger<VersionService> logger)
     {
+        this.hostEnvironment = hostEnvironment;
         this.versionApi = versionApi;
         this.logger = logger;
         var assembly = Assembly.GetEntryAssembly()!;
@@ -99,8 +103,8 @@ public class VersionService : IVersionService
     {
         try
         {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            return await versionApi.SetInformation(environment ?? "", system, comp, version, status);
+            var environment = hostEnvironment.EnvironmentName;
+            return await versionApi.SetInformation(environment, system, comp, version, status);
         }
         catch (ApiException e)
         {

--- a/Fhi.VersionApiClient/VersionService.cs
+++ b/Fhi.VersionApiClient/VersionService.cs
@@ -123,7 +123,7 @@ public class VersionService : IVersionService
     {
         try
         {
-            var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+            var environment = hostEnvironment.EnvironmentName;
             return await versionApi.GetInformation(environment ?? "", system, comp);
         }
         catch (ApiException e)


### PR DESCRIPTION
## Problem
When using `WebApplicationFactory` and specifying `UseEnvironment` it is not fetched when using `Environment.GetEnvironmentVariable`. The value is then `null`.

## Solution
Get environment from IHostEnvironment

## Question
Will this work with IIS?
We have to make sure that this code also works when using IIS.